### PR TITLE
Add requirements file for pip install of dev versions

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -50,14 +50,14 @@ bc.conda_packages = ['acstools',
                      'setuptools',
                      'pip',
                      'python=3.6']
-bc.build_cmds = ["pip install --no-deps -e ."]
+bc.build_cmds = ["pip install --no-deps -r requirements-dev.txt -e ."]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
 bc.test_configs = [data_config]
 
 bc1 = utils.copy(bc)
 bc1.name = '3.6-dev'
 bc1.conda_channels = ['http://ssb.stsci.edu/conda-dev']
-bc1.build_cmds = ["pip install --upgrade -e ."]
+bc1.build_cmds = ["pip install -r requirements-dev.txt --upgrade -e ."]
 
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -27,13 +27,13 @@ jobs:
         architecture: 'x64'
 
     - bash: |
-        export PIP_INSTALL='pip install --upgrade'
+        export PIP_INSTALL='pip install -r requirements-dev.txt --upgrade'
         echo "##vso[task.setvariable variable=PIP_INSTALL]$PIP_INSTALL"
       condition: ne( variables['Agent.OS'], 'Windows_NT' )
       displayName: Pip on Linux/Darwin
 
     - powershell: |
-        Set-Variable -Name PIP_INSTALL -Value 'python -m pip install --upgrade'
+        Set-Variable -Name PIP_INSTALL -Value 'python -m pip install -r requirements-dev.txt --upgrade'
         Write-Host "##vso[task.setvariable variable=PIP_INSTALL]$PIP_INSTALL"
       condition: eq( variables['Agent.OS'], 'Windows_NT' )
       displayName: Pip on Windows
@@ -57,4 +57,3 @@ jobs:
       inputs:
         testResultsFiles: '**/test-*.xml'
         testRunTitle: 'Python $(python.version)-${{ format(parameters.name) }}'
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+git+https://github.com/spacetelescope/stwcs.git@e1da1f11736b2507afd92cf045eedba717d9e820#egg=stwcs
+git+https://github.com/astropy/photutils.git@da9fa2423160c0acfc7ac4c7d7a29461dbc0e534#egg=photutils
+git+https://github.com/spacetelescope/stsci.tools@9a022503ad24ca54ce83331482dfa3ff6de9f403#egg=stsci.tools

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         'stsci.skypac',
         'stsci.stimage',
         'stwcs',
-        'tweakwcs>=0.4.0',
+        'tweakwcs>=0.5.0',
         'stregion',
         'requests',
         # HLA-pipeline specific:


### PR DESCRIPTION
This adds, and implements?, a new requirements-dev.txt file for pip installing versions of dependent packages which have not been tagged or released yet.